### PR TITLE
[New] Add displaying description of entity attribute on CRUD page

### DIFF
--- a/easydata.js/packs/core/src/data/data_column.ts
+++ b/easydata.js/packs/core/src/data/data_column.ts
@@ -15,38 +15,48 @@ export interface DataColumnStyle
 }
 
 export interface DataColumnDescriptor {
-    /** Represents internal column id. */
+    /** Represents the internal column ID. */
     id: string;
-    /** Represents original internal column id. */
+
+    /** Represents the ID of the metadata attribute this column is based on. */
     originAttrId?: string;
-    /** The type of data represented by column. */
+
+    /** The type of data represented by the column. */
     type?: DataType;
-    /** Name to use for this column in the UI. */
+
+    /** The label that is used for this column in UI. */
     label: string;
+
+    /** Indicates whether this column is an aggregate one. */
     isAggr?: boolean;
+
     /** The display format for the column. */
     dfmt?: string;
+
     gfct?: string;
+
     /** The style of the column to display in UI. */
     style?: DataColumnStyle;
-    /** Detailed description of the column. */
-    desc: string | null;
+
+    /** The detailed column description. */
+    description: string | null;
 }
 
 export class DataColumn {
 
-    /** The type of data represented by column. */
+    /** The type of data represented by the column. */
     public readonly type: DataType;
 
-    /** Represents internal column id. */
+    /** Represents the internal column ID. */
     public readonly id: string;
 
+    /** Indicates whether this column is an aggregate one. */
     public readonly isAggr: boolean;
 
-    /** Represents original internal column id. */
+    /** Represents the ID of the metadata attribute this column is based on. */
     public readonly originAttrId?: string;
 
-    /** Name to use for this column in the UI. */
+    /** The label that is used for this column in UI. */
     public label: string;
 
     /** The display format for the column. */
@@ -57,7 +67,7 @@ export class DataColumn {
     /** The style of the column to display in UI. */
     public style?: DataColumnStyle;
 
-    /** Column description. */
+    /** The column description. */
     public description: string | null;
 
     constructor(desc: DataColumnDescriptor) {
@@ -78,7 +88,7 @@ export class DataColumn {
         this.displayFormat = desc.dfmt;
         this.groupFooterColumnTemplate = desc.gfct;
         this.style = desc.style || {};
-        this.description = desc.desc;
+        this.description = desc.description;
     }
 }
 

--- a/easydata.js/packs/core/src/data/data_column.ts
+++ b/easydata.js/packs/core/src/data/data_column.ts
@@ -15,33 +15,50 @@ export interface DataColumnStyle
 }
 
 export interface DataColumnDescriptor {
+    /** Represents internal column id. */
     id: string;
+    /** Represents original internal column id. */
     originAttrId?: string;
+    /** The type of data represented by column. */
     type?: DataType;
+    /** Name to use for this column in the UI. */
     label: string;
     isAggr?: boolean;
+    /** The display format for the column. */
     dfmt?: string;
     gfct?: string;
+    /** The style of the column to display in UI. */
     style?: DataColumnStyle;
+    /** Detailed description of the column. */
+    description: string | null;
 }
 
 export class DataColumn {
 
+    /** The type of data represented by column. */
     public readonly type: DataType;
 
+    /** Represents internal column id. */
     public readonly id: string;
 
     public readonly isAggr: boolean;
 
+    /** Represents original internal column id. */
     public readonly originAttrId?: string;
 
+    /** Name to use for this column in the UI. */
     public label: string;
 
+    /** The display format for the column. */
     public displayFormat?: string;
 
     public groupFooterColumnTemplate?: string;
 
+    /** The style of the column to display in UI. */
     public style?: DataColumnStyle;
+
+    /** Column description. */
+    public description: string | null;
 
     constructor(desc: DataColumnDescriptor) {
         if (!desc)
@@ -61,6 +78,7 @@ export class DataColumn {
         this.displayFormat = desc.dfmt;
         this.groupFooterColumnTemplate = desc.gfct;
         this.style = desc.style || {};
+        this.description = desc.description;
     }
 }
 

--- a/easydata.js/packs/core/src/data/data_column.ts
+++ b/easydata.js/packs/core/src/data/data_column.ts
@@ -30,7 +30,7 @@ export interface DataColumnDescriptor {
     /** The style of the column to display in UI. */
     style?: DataColumnStyle;
     /** Detailed description of the column. */
-    description: string | null;
+    desc: string | null;
 }
 
 export class DataColumn {
@@ -78,7 +78,7 @@ export class DataColumn {
         this.displayFormat = desc.dfmt;
         this.groupFooterColumnTemplate = desc.gfct;
         this.style = desc.style || {};
-        this.description = desc.description;
+        this.description = desc.desc;
     }
 }
 

--- a/easydata.js/packs/crud/src/form/entity_form_builder.ts
+++ b/easydata.js/packs/crud/src/form/entity_form_builder.ts
@@ -394,41 +394,41 @@ export class EntityEditFormBuilder {
             .addChild('label', b => b
                 .attr('for', attr.id)
                 .addHtml(`${attr.caption} ${required ? '<sup style="color: red">*</sup>' : ''}: `)
-            ).addChild('div');
-
-        let fieldHolder = parent.lastChild as HTMLElement;
+            );
+        
+        const fieldSlot = domel('div', parent).toDOM()
 
         if (attr.kind === EntityAttrKind.Lookup) {
-            this.setupLookupField(fieldHolder, attr, readOnly, value);
+            this.setupLookupField(fieldSlot, attr, readOnly, value);
         }
         else {
             switch (editor.tag) {
                 case EditorTag.DateTime:
-                    this.setupDateTimeField(fieldHolder, attr, readOnly, value);
+                    this.setupDateTimeField(fieldSlot, attr, readOnly, value);
                     break;
     
                 case EditorTag.List:
-                    this.setupListField(fieldHolder, attr, readOnly, editor.values, value);
+                    this.setupListField(fieldSlot, attr, readOnly, editor.values, value);
                     break;
     
                 case EditorTag.File:
-                    this.setupFileField(fieldHolder, attr, readOnly, editor.accept);
+                    this.setupFileField(fieldSlot, attr, readOnly, editor.accept);
                     break;
     
                 case EditorTag.Edit:
                 default:
                     if (editor.multiline) {
-                        this.setupTextArea(fieldHolder, attr, readOnly, value);
+                        this.setupTextArea(fieldSlot, attr, readOnly, value);
                     }
                     else {
-                        this.setupTextField(fieldHolder, attr, readOnly, value);
+                        this.setupTextField(fieldSlot, attr, readOnly, value);
                     }
                     break;
             }
         }
 
         if (attr.description) {
-            domel(fieldHolder).addChild('small', b => b
+            domel(fieldSlot).addChild('small', b => b
                 .addText(attr.description)
             );
         }

--- a/easydata.js/packs/crud/src/form/entity_form_builder.ts
+++ b/easydata.js/packs/crud/src/form/entity_form_builder.ts
@@ -391,46 +391,49 @@ export class EntityEditFormBuilder {
         }
 
         domel(parent)
-            .addChild('label', b => b
-                .attr('for', attr.id)
-                .addHtml(`${attr.caption} ${required ? '<sup style="color: red">*</sup>' : ''}: `)
+            .addChild('label', b => {
+                b.attr('for', attr.id);
+                b.addHtml(`${attr.caption} ${required ? '<sup style="color: red">*</sup>' : ''}: `);
+
+                if (attr.description) {
+                    b.addChild('div', b => b
+                        .attr('title', attr.description)
+                        .addClass('question-mark')
+                        .setStyle('vertical-align', 'middle')
+                        .setStyle('display', 'inline-block')
+                    );
+                }
+            }
+
             );
         
-        const fieldSlot = domel('div', parent).toDOM()
-
         if (attr.kind === EntityAttrKind.Lookup) {
-            this.setupLookupField(fieldSlot, attr, readOnly, value);
-        }
-        else {
-            switch (editor.tag) {
-                case EditorTag.DateTime:
-                    this.setupDateTimeField(fieldSlot, attr, readOnly, value);
-                    break;
-    
-                case EditorTag.List:
-                    this.setupListField(fieldSlot, attr, readOnly, editor.values, value);
-                    break;
-    
-                case EditorTag.File:
-                    this.setupFileField(fieldSlot, attr, readOnly, editor.accept);
-                    break;
-    
-                case EditorTag.Edit:
-                default:
-                    if (editor.multiline) {
-                        this.setupTextArea(fieldSlot, attr, readOnly, value);
-                    }
-                    else {
-                        this.setupTextField(fieldSlot, attr, readOnly, value);
-                    }
-                    break;
-            }
+            this.setupLookupField(parent, attr, readOnly, value);
+            return;
         }
 
-        if (attr.description) {
-            domel(fieldSlot).addChild('small', b => b
-                .addText(attr.description)
-            );
+        switch (editor.tag) {
+            case EditorTag.DateTime:
+                this.setupDateTimeField(parent, attr, readOnly, value);
+                break;
+
+            case EditorTag.List:
+                this.setupListField(parent, attr, readOnly, editor.values, value);
+                break;
+
+            case EditorTag.File:
+                this.setupFileField(parent, attr, readOnly, editor.accept);
+                break;
+
+            case EditorTag.Edit:
+            default:
+                if (editor.multiline) {
+                    this.setupTextArea(parent, attr, readOnly, value);
+                }
+                else {
+                    this.setupTextField(parent, attr, readOnly, value);
+                }
+                break;
         }
     }
 

--- a/easydata.js/packs/crud/src/form/entity_form_builder.ts
+++ b/easydata.js/packs/crud/src/form/entity_form_builder.ts
@@ -394,35 +394,43 @@ export class EntityEditFormBuilder {
             .addChild('label', b => b
                 .attr('for', attr.id)
                 .addHtml(`${attr.caption} ${required ? '<sup style="color: red">*</sup>' : ''}: `)
-            );
+            ).addChild('div');
+
+        let fieldHolder = parent.lastChild as HTMLElement;
 
         if (attr.kind === EntityAttrKind.Lookup) {
-            this.setupLookupField(parent, attr, readOnly, value);
-            return;
+            this.setupLookupField(fieldHolder, attr, readOnly, value);
+        }
+        else {
+            switch (editor.tag) {
+                case EditorTag.DateTime:
+                    this.setupDateTimeField(fieldHolder, attr, readOnly, value);
+                    break;
+    
+                case EditorTag.List:
+                    this.setupListField(fieldHolder, attr, readOnly, editor.values, value);
+                    break;
+    
+                case EditorTag.File:
+                    this.setupFileField(fieldHolder, attr, readOnly, editor.accept);
+                    break;
+    
+                case EditorTag.Edit:
+                default:
+                    if (editor.multiline) {
+                        this.setupTextArea(fieldHolder, attr, readOnly, value);
+                    }
+                    else {
+                        this.setupTextField(fieldHolder, attr, readOnly, value);
+                    }
+                    break;
+            }
         }
 
-        switch (editor.tag) {
-            case EditorTag.DateTime:
-                this.setupDateTimeField(parent, attr, readOnly, value);
-                break;
-
-            case EditorTag.List:
-                this.setupListField(parent, attr, readOnly, editor.values, value);
-                break;
-
-            case EditorTag.File:
-                this.setupFileField(parent, attr, readOnly, editor.accept);
-                break;
-
-            case EditorTag.Edit:
-            default:
-                if (editor.multiline) {
-                    this.setupTextArea(parent, attr, readOnly, value);
-                }
-                else {
-                    this.setupTextField(parent, attr, readOnly, value);
-                }
-                break;
+        if (attr.description) {
+            domel(fieldHolder).addChild('small', b => b
+                .addText(attr.description)
+            );
         }
     }
 

--- a/easydata.js/packs/ui/assets/css/easy-grid.css
+++ b/easydata.js/packs/ui/assets/css/easy-grid.css
@@ -331,3 +331,11 @@
 .eqjs-chart-content canvas {
     max-height: 100%;
 }
+
+.question-mark {
+    position: relative;
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACE4AAAhOAYwxAOwAAAFgSURBVDhPbdK7K4dRHMfxn1sWUVhcihK/MBKlbMqGKAplMMglk7JJRpOy+R8sJotBiUUiSe6XWNxGpYT3++k5Tw/51Kvfc06/c/2enMzv2K5CCxpRgmecYB+vSJIX/5oCTGINnXjBG+owjXE84gzfSOLAZRxiKG6nU4QpnGIWyY79mIEDa+N2LirRhvK4Tx24Qx+iVOMarhhmHICr7MFJ22GcdB47KLajF8fIt0GcYBujcLur2EBIIa7Q5Eze6hY+ETKCdXzA838hxL4jZB1sOZ4Q4k0+wJ1sogtLSMdKlDnYOtbY8ycNsEzDOLAjFd+CZct04wKeLx3brfCM6ZTiFvWu7MvxTGMIt20slbWNbjWOj2oB54hWNv2wNNbRCU0FJhAGO3AQN/B/SRzgy7mHdfxvqytwYI8dJr1Nv635HFzVcnirXk4z3OoidhElPTjEbfrqsiiDZ7uMf98RJ5P5AUhxQvegD107AAAAAElFTkSuQmCC') no-repeat center;
+    width: 20px;
+    height: 20px;
+    margin-left: 5px;
+}

--- a/easydata.js/packs/ui/src/grid/easy_grid.ts
+++ b/easydata.js/packs/ui/src/grid/easy_grid.ts
@@ -393,6 +393,12 @@ export class EasyGrid {
                 .text(column.label);
         }
 
+        if (column.description) {
+            domel('div', colDiv)
+                .addClass('question-mark')
+                .title(column.description);
+        }
+        
         if (this.options.allowDragDrop) {
             eqDragManager.registerDraggableItem({
                 element: colDiv,
@@ -672,7 +678,7 @@ export class EasyGrid {
         let result: any = {}
         for (const colId of group.columns) {
             let keyVal =  row.getValue(colId);
-            if (caseInsensitive && typeof(keyVal) === 'string') {
+            if (caseInsensitive) {
                 keyVal = keyVal.toLowerCase();
             }
             result[colId] = keyVal;

--- a/easydata.js/packs/ui/src/grid/easy_grid.ts
+++ b/easydata.js/packs/ui/src/grid/easy_grid.ts
@@ -678,7 +678,7 @@ export class EasyGrid {
         let result: any = {}
         for (const colId of group.columns) {
             let keyVal =  row.getValue(colId);
-            if (caseInsensitive) {
+            if (caseInsensitive && typeof(keyVal) === 'string') {
                 keyVal = keyVal.toLowerCase();
             }
             result[colId] = keyVal;

--- a/easydata.js/packs/ui/src/grid/easy_grid_columns.ts
+++ b/easydata.js/packs/ui/src/grid/easy_grid_columns.ts
@@ -39,6 +39,7 @@ function MapAlignment(alignment: ColumnAlignment): GridColumnAlign {
 export class GridColumn {
     private _label : string = null;
     private grid: EasyGrid;
+    private _description: string = null;
 
     public readonly dataColumn: DataColumn;
 
@@ -77,6 +78,7 @@ export class GridColumn {
             }
 
             this.cellRenderer = this.grid.cellRendererStore.getDefaultRenderer(column.type);
+            this._description = column.description;
         }
         else if (isRowNum) {
             this.isRowNum = true;
@@ -97,6 +99,11 @@ export class GridColumn {
 
     public set label(value: string) {
         this._label = this.label;
+    }
+
+    /** Get column description. */
+    public get description(): string {
+        return this._description;
     }
 
     public get type(): DataType {

--- a/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
+++ b/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
@@ -24,34 +24,37 @@ namespace EasyData
     public class EasyDataColDesc
     {
         /// <summary>
-        /// Represents internal property id.
+        /// Represents the internal column ID.
         /// </summary>
         public string Id { get; set; }
 
         /// <summary>
-        /// Index of property.
+        /// Represents the order number of this column among all columns in the result set.
         /// </summary>
         public int Index { get; set; }
 
+        /// <summary>
+        /// Indicates whether this column is an aggregate one.
+        /// </summary>
         public bool IsAggr { get; set; }
 
         /// <summary>
-        /// Name to use for this property in the UI.
+        /// The label that is used for this column in UI.
         /// </summary>
         public string Label { get; set; }
 
         /// <summary>
-        /// Detailed description of the property.
+        /// The detailed column description.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        /// The type of data represented by property.
+        /// The type of data represented by the property.
         /// </summary>
         public DataType DataType { get; set; }
 
         /// <summary>
-        /// Represents internal property id.
+        /// Represents internal property ID.
         /// </summary>
         public string AttrId { get; set; }
 
@@ -73,47 +76,50 @@ namespace EasyData
     public class EasyDataCol
     {
         /// <summary>
-        /// Represents internal property id.
+        /// Represents the internal column ID.
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; }
 
         /// <summary>
-        /// Index of property.
+        /// Represents the order number of this column among all columns in the result set.
         /// </summary>
         [JsonIgnore]
         public int Index { get; }
 
+        /// <summary>
+        /// Indicates whether this column is an aggregate one.
+        /// </summary>
         [JsonProperty("isAggr")]
         public bool IsAggr { get; }
 
         /// <summary>
-        /// Name to use for this property in the UI.
+        /// The label that is used for this column in UI.
         /// </summary>
         [JsonProperty("label")]
         public string Label { get; set; }
 
         /// <summary>
-        /// Detailed description of the property.
+        /// The detailed column description.
         /// </summary>
-        [JsonProperty("desc")]
+        [JsonProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
-        /// The type of data represented by property.
+        /// The type of data represented by the property.
         /// </summary>
         [Obsolete("Use DataType instead")]
         [JsonIgnore]
         public DataType Type => DataType;
 
         /// <summary>
-        /// The type of data represented by property.
+        /// The type of data represented by the property.
         /// </summary>
         [JsonProperty("type")]
         public DataType DataType { get; }
 
         /// <summary>
-        /// Represents original internal property id.
+        /// Represents the ID of the metadata attribute this column is based on.
         /// </summary>
         [JsonProperty("originAttrId")]
         public string OrginAttrId { get; }

--- a/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
+++ b/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
@@ -96,7 +96,7 @@ namespace EasyData
         /// <summary>
         /// Detailed description of the property.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonProperty("desc")]
         public string Description { get; set; }
 
         /// <summary>

--- a/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
+++ b/easydata.net/src/EasyData.Core/EasyDataResultSet.cs
@@ -7,8 +7,8 @@ using Newtonsoft.Json;
 namespace EasyData
 {
 
-    public enum ColumnAlignment 
-    { 
+    public enum ColumnAlignment
+    {
         None,
         Left,
         Center,
@@ -23,22 +23,48 @@ namespace EasyData
 
     public class EasyDataColDesc
     {
+        /// <summary>
+        /// Represents internal property id.
+        /// </summary>
         public string Id { get; set; }
 
+        /// <summary>
+        /// Index of property.
+        /// </summary>
         public int Index { get; set; }
 
         public bool IsAggr { get; set; }
 
+        /// <summary>
+        /// Name to use for this property in the UI.
+        /// </summary>
         public string Label { get; set; }
 
+        /// <summary>
+        /// Detailed description of the property.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The type of data represented by property.
+        /// </summary>
         public DataType DataType { get; set; }
 
+        /// <summary>
+        /// Represents internal property id.
+        /// </summary>
         public string AttrId { get; set; }
 
+        /// <summary>
+        /// The display format for the property.
+        /// </summary>
         public string DisplayFormat { get; set; }
 
         public string GroupFooterColumnTemplate { get; set; }
 
+        /// <summary>
+        /// The style of the property to display in UI.
+        /// </summary>
         public EasyDataColStyle Style { get; set; }
 
 
@@ -46,34 +72,64 @@ namespace EasyData
 
     public class EasyDataCol
     {
+        /// <summary>
+        /// Represents internal property id.
+        /// </summary>
         [JsonProperty("id")]
-        public string Id { get;  }
+        public string Id { get; }
 
+        /// <summary>
+        /// Index of property.
+        /// </summary>
         [JsonIgnore]
-        public int Index { get;  }
+        public int Index { get; }
 
         [JsonProperty("isAggr")]
-        public bool IsAggr { get;  }
+        public bool IsAggr { get; }
 
+        /// <summary>
+        /// Name to use for this property in the UI.
+        /// </summary>
         [JsonProperty("label")]
         public string Label { get; set; }
 
+        /// <summary>
+        /// Detailed description of the property.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The type of data represented by property.
+        /// </summary>
         [Obsolete("Use DataType instead")]
         [JsonIgnore]
         public DataType Type => DataType;
 
+        /// <summary>
+        /// The type of data represented by property.
+        /// </summary>
         [JsonProperty("type")]
         public DataType DataType { get; }
 
+        /// <summary>
+        /// Represents original internal property id.
+        /// </summary>
         [JsonProperty("originAttrId")]
         public string OrginAttrId { get; }
 
+        /// <summary>
+        /// The display format for the property.
+        /// </summary>
         [JsonProperty("dfmt")]
         public string DisplayFormat { get; set; }
 
         [JsonProperty("gfct")]
         public string GroupFooterColumnTemplate { get; set; }
 
+        /// <summary>
+        /// The style of the property to display in UI.
+        /// </summary>
         [JsonProperty("style")]
         public EasyDataColStyle Style { get; }
 
@@ -85,6 +141,7 @@ namespace EasyData
             IsAggr = desc.IsAggr;
             OrginAttrId = desc.AttrId;
             Label = desc.Label;
+            Description = desc.Description;
             DataType = desc.DataType;
             DisplayFormat = desc.DisplayFormat;
             GroupFooterColumnTemplate = desc.GroupFooterColumnTemplate;
@@ -101,7 +158,8 @@ namespace EasyData
         }
     }
 
-    public interface IEasyDataResultSet {
+    public interface IEasyDataResultSet
+    {
         /// <summary>
         /// Gets columns
         /// </summary>
@@ -114,7 +172,7 @@ namespace EasyData
     }
 
 
-    public class EasyDataResultSet: IEasyDataResultSet
+    public class EasyDataResultSet : IEasyDataResultSet
     {
         [JsonProperty("cols")]
         public List<EasyDataCol> Cols { get; } = new List<EasyDataCol>();

--- a/easydata.net/src/EasyData.EntityFrameworkCore.Relational/Services/EasyDataManagerEF.cs
+++ b/easydata.net/src/EasyData.EntityFrameworkCore.Relational/Services/EasyDataManagerEF.cs
@@ -87,7 +87,8 @@ namespace EasyData.Services
                     Label = DataUtils.PrettifyName(prop.Name),
                     AttrId = attr?.Id,
                     DisplayFormat = dfmt,
-                    DataType = dataType
+                    DataType = dataType,
+                    Description = attr.Description
                 }));
             }
 


### PR DESCRIPTION
Hey) I suggest adding a help text from the properties description to the fields in the grid and entity editing form. What do you think about it?

![image](https://user-images.githubusercontent.com/81791194/141973181-520ada7f-5ffe-408c-ab93-346daa8c657f.png)
![image](https://user-images.githubusercontent.com/81791194/141973196-4e877769-9e29-45cd-8780-d5ea9468ce59.png)
![image](https://user-images.githubusercontent.com/81791194/141973211-4f54a433-563d-441a-be1d-b18fec8087a1.png)
