### PR TITLE
Fix Readme after change api

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ We also add EasyData styles and the script file (`easydata.min.js`), which rende
     ViewData["Title"] = "EasyData";
 }
 
-<link rel="stylesheet" href="https://cdn.korzh.com/ed/1.3.0/easydata.min.css" />
+<link rel="stylesheet" href="https://cdn.korzh.com/ed/1.4.8/easydata.min.css" />
 
 <div id="EasyDataContainer"></div>
 
 @section Scripts {
-    <script src="https://cdn.korzh.com/ed/1.3.0/easydata.min.js" type="text/javascript"></script>
+    <script src="https://cdn.korzh.com/ed/1.4.8/easydata.min.js" type="text/javascript"></script>
     <script>
         window.addEventListener('load', function () {
             new easydata.crud.EasyDataViewDispatcher().run()


### PR DESCRIPTION
In commit https://github.com/KorzhCom/EasyData/commit/7fa9d322c1619719bbebad79357806322f95f664 api was changed without compatibility, with version 1.3.0 from readme, easy data doesn't work.