### PR TITLE
Remove sufix "es"

### DIFF
--- a/easydata.net/src/EasyData.EntityFrameworkCore.Relational/MetaDataLoader/DbContextMetaDataLoader.cs
+++ b/easydata.net/src/EasyData.EntityFrameworkCore.Relational/MetaDataLoader/DbContextMetaDataLoader.cs
@@ -215,7 +215,7 @@ namespace EasyData.EntityFrameworkCore
 
             entity.ClrType = entityType.ClrType;
 
-            entity.NamePlural = DataUtils.MakePlural(entity.Name);
+            entity.NamePlural = entity.Name; // DataUtils.MakePlural(entity.Name);
 
             var annotation = (MetaEntityAttribute)entityType.ClrType.GetCustomAttribute(typeof(MetaEntityAttribute));
             if (annotation != null) {


### PR DESCRIPTION
Adding a sufix to the end of each table name looks very bad. More information is described here. https://github.com/KorzhCom/EasyData/issues/153
I don't think this is a needed feature (even my client laughed about it when he asked me if I was exaggerating).
Alternatively, you can make settings

